### PR TITLE
ルーティング作成

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --proxy-config proxy.conf.json",
+    "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/client/proxy.conf.json
+++ b/client/proxy.conf.json
@@ -1,6 +1,0 @@
-{
-  "**": {
-    "target": "http://localhost:3000",
-    "secure": false
-  }
-}

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -1,7 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { EventComponent } from './components/event/event.component';
+import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', component: EventComponent },
+  { path: 'api/v1/events', component: EventComponent },
+  { path: '**', component: PageNotFoundComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,2 +1,3 @@
 {{title}}
+<a routerLink="/api/v1/events" routerLinkActive="active">イベント一覧</a>
 <router-outlet></router-outlet>

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,3 +1,2 @@
 {{title}}
-
-<event></event>
+<router-outlet></router-outlet>

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -6,11 +6,13 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { EventComponent } from './components/event/event.component';
 import { EventService } from './services/event/event.service';
+import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    EventComponent
+    EventComponent,
+    PageNotFoundComponent
   ],
   imports: [
     BrowserModule,

--- a/client/src/app/components/page-not-found/page-not-found.component.html
+++ b/client/src/app/components/page-not-found/page-not-found.component.html
@@ -1,1 +1,2 @@
-<p>page-not-found works!</p>
+<div>404</div>
+<h3>ページが見つかりません</h3>

--- a/client/src/app/components/page-not-found/page-not-found.component.html
+++ b/client/src/app/components/page-not-found/page-not-found.component.html
@@ -1,0 +1,1 @@
+<p>page-not-found works!</p>

--- a/client/src/app/components/page-not-found/page-not-found.component.spec.ts
+++ b/client/src/app/components/page-not-found/page-not-found.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PageNotFoundComponent } from './page-not-found.component';
+
+describe('PageNotFoundComponent', () => {
+  let component: PageNotFoundComponent;
+  let fixture: ComponentFixture<PageNotFoundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PageNotFoundComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PageNotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/components/page-not-found/page-not-found.component.ts
+++ b/client/src/app/components/page-not-found/page-not-found.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-page-not-found',
+  templateUrl: './page-not-found.component.html',
+  styleUrls: ['./page-not-found.component.scss']
+})
+export class PageNotFoundComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/client/src/app/services/event/event.service.spec.ts
+++ b/client/src/app/services/event/event.service.spec.ts
@@ -53,7 +53,7 @@ describe('EventService', () => {
           expect(events).toEqual(mockEvents);
         });
 
-      const req = httpTestingController.expectOne('http://localhost:4200/api/v1/events');
+      const req = httpTestingController.expectOne('http://localhost:3000/api/v1/events');
       expect(req.request.method).toEqual('GET');
       req.flush(mockEvents);
     })
@@ -73,7 +73,7 @@ describe('EventService', () => {
           err => expect(err).toEqual(mockErrorResponse)
         );
 
-      const req = httpTestingController.expectOne('http://localhost:4200/api/v1/events');
+      const req = httpTestingController.expectOne('http://localhost:3000/api/v1/events');
       expect(req.request.method).toEqual('GET');
 
       req.flush(mockErrorResponse)

--- a/client/src/app/services/event/event.service.ts
+++ b/client/src/app/services/event/event.service.ts
@@ -14,12 +14,9 @@ export class EventService {
       'Content-Type': 'application/json'
     }),
   };
-  /*
-   * バックエンドはポート番号「3000」で待ち受けているため、そのまま指定すると CORS でエラーになる
-   * それを回避するため、ここではフロントエンドのポート番号「4200」を指定し、
-   * Angular CLI のリバースプロキシを利用してバックエンドとの通信を実現する
-   */
-  private host: string = 'http://localhost:4200';
+
+  // TODO: 環境ごとに切り替えるようにする
+  private host: string = 'http://localhost:3000';
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
## 概要
リバースプロキシの設定を削除
- リバースプロキシでAngularからの `http://localhost:4200` リクエストを `http://localhost:3000` に書き換えるようにしていた
- Rails側でcors対策として、`http://localhost:4200` からのアクセスを許可しているので上記の書き換えは必要なさそう

