### PR TITLE
ジャンルidよりジャンル名を表示する

### DIFF
--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,8 +1,12 @@
 class EventSerializer < ActiveModel::Serializer
   attributes :id, :name, :date, :prefecture, :address1, :address2, :description,
-    :genre_id, :created_at, :updated_at
+    :genre, :created_at, :updated_at
 
   def prefecture
     Prefecture.find(object.prefecture_id).name
+  end
+
+  def genre
+    Genre.find(object.genre_id).name
   end
 end

--- a/client/src/app/components/event-detail/event-detail.component.html
+++ b/client/src/app/components/event-detail/event-detail.component.html
@@ -15,6 +15,10 @@
       <td>{{event.name}}</td>
     </tr>
     <tr>
+      <td>イベントジャンル</td>
+      <td>{{event.genre}}</td>
+    </tr>
+    <tr>
       <td>場所</td>
       <td>{{event.prefecture}}{{event.address1}}{{event.address2}}</td>
     </tr>

--- a/client/src/app/models/event.ts
+++ b/client/src/app/models/event.ts
@@ -6,5 +6,5 @@ export class Event {
   address1?: string | null;
   address2?: string | null;
   description?: string | null;
-  genre_id?: number | null;
+  genre?: string | null;
 }

--- a/client/src/app/services/event/event.service.spec.ts
+++ b/client/src/app/services/event/event.service.spec.ts
@@ -37,7 +37,7 @@ describe('EventService', () => {
           address1: '中央区日本橋小舟町3452',
           address2: '3452ビル 2階',
           description: '中級クラスのグループレッスンです。テーマは「軸の使い方」です。',
-          genre_id: 1 },
+          genre: 'レッスン' },
         { id: 2,
           name: 'vamosミロンガ',
           date: '2021-07-20T10:00:00.000Z',
@@ -45,7 +45,7 @@ describe('EventService', () => {
           address1: '千代田区三番町1-5-5',
           address2: '三番町第2ビル4F',
           description: 'welcome!!',
-          genre_id: 1 }
+          genre: 'ミロンガ' }
       ];
 
       service.getEvents()

--- a/client/src/app/services/event/event.service.stub.ts
+++ b/client/src/app/services/event/event.service.stub.ts
@@ -13,7 +13,7 @@ export class EventServiceStub {
           address1: '中央区日本橋小舟町3452',
           address2: '3452ビル 2階',
           description: '中級クラスのグループレッスンです。テーマは「軸の使い方」です。',
-          genre_id: 1 },
+          genre: 'レッスン' },
         { id: 2,
           name: 'vamosミロンガ',
           date: '2021-07-20T10:00:00.000Z',
@@ -21,7 +21,7 @@ export class EventServiceStub {
           address1: '千代田区三番町1-5-5',
           address2: '三番町第2ビル4F',
           description: 'welcome!!',
-          genre_id: 1 }
+          genre: 'ミロンガ' }
       ]
     );
   }
@@ -35,7 +35,7 @@ export class EventServiceStub {
         address1: '中央区日本橋小舟町3452',
         address2: '3452ビル 2階',
         description: '中級クラスのグループレッスンです。テーマは「軸の使い方」です。',
-        genre_id: 1 }
+        genre: 'レッスン' }
     );
   }
 }


### PR DESCRIPTION
## 概要
APIから `genre_id` を返していた箇所を、ジャンル名を返すように変更した。

## 動作確認
イベントジャンルにジャンル名「ミロンガ」が表示されている
<img width="644" alt="スクリーンショット 2021-06-19 11 55 42" src="https://user-images.githubusercontent.com/52645663/122629086-52398b80-d0f5-11eb-97af-550f9d076c89.png">
